### PR TITLE
Adding an issue link to the issue creation workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,4 @@
+contact_links:
+    - name: Ask the Hugo community
+      url: https://discourse.gohugo.io/
+      about: If your request is "not really" a bug or you are unsure about it, or if this is just a configuration or an adaption request feel free to ask in our community for help


### PR DESCRIPTION
This config enables us to add external links to the process of creating new issues. I propose to add a friendly link to the community, just in case the issue opener is not aware of this forum.